### PR TITLE
Fix typeerror in python3.6

### DIFF
--- a/FusionIcon/util.py
+++ b/FusionIcon/util.py
@@ -76,7 +76,7 @@ class CompizOption(object):
 		return self.config.getboolean('compiz options', self.name)
 
 	def __set(self, value):
-		print(' * Setting option ' + self.label + ' to ' + value)
+		print(' * Setting option ' + self.label + ' to ' + str(value))
 		self.config.set('compiz options', self.name, str(bool(value)).lower())
 		self.config.write(open(self.config.config_file, 'w'))
 


### PR DESCRIPTION
```
Traceback (most recent call last):
  File "/usr/lib/python3.6/site-packages/FusionIcon/interface_qt/main.py", line 70, in <lambda>
    actionOP = self.Tray.optionsMenu.addAction(options[option].label, lambda val=option: self.toggleOP(val))
  File "/usr/lib/python3.6/site-packages/FusionIcon/interface_qt/main.py", line 40, in toggleOP
    options[option].enabled = not options[option].enabled
  File "/usr/lib/python3.6/site-packages/FusionIcon/util.py", line 80, in __set
    print(' * Setting option ' + self.label + ' to ' + value)
TypeError: must be str, not bool
[1]    5680 abort (core dumped)  fusion-icon
```
fix type error in python 3.6