### PR TITLE
Patch

### DIFF
--- a/FusionIcon/data.py
+++ b/FusionIcon/data.py
@@ -81,8 +81,8 @@ wms = {
 		 'KWin4', 'kde', None, None),
 
 	'xfwm4':
-		('xfwm4', ['xfwm4'],
-		 'Xfwm4', 'xfce', ['noreplace'], ['killall', 'xfwm4']),
+		('xfwm4', ['xfwm4', '--replace'],
+		 'Xfwm4', 'xfce', None, None),
 
 	'openbox':
 		('openbox', ['openbox', '--replace'],

--- a/FusionIcon/data.py
+++ b/FusionIcon/data.py
@@ -104,16 +104,16 @@ wms = {
 
 #decorator
 #	base command, full command line,
-#	label, desktop environment
+#	label, desktop environment, proc name
 
 decorators = {
 	'emerald':
 		('emerald', 'emerald --replace',
-		 'Emerald', None),
+		 'Emerald', None, 'emerald'),
 
 	'gwd':
 		('gtk-window-decorator', 'gtk-window-decorator --replace',
-		 'GTK+ Window Decorator', 'mate'),
+		 'GTK+ Window Decorator', 'mate', 'gtk-window-deco'),
 }
 
 #option:

--- a/FusionIcon/util.py
+++ b/FusionIcon/util.py
@@ -174,7 +174,7 @@ class WindowManagers(dict):
 
 			kill_list = ['killall']
 			for decorator in decorators:
-				kill_list.append(decorators[decorator].base)
+				kill_list.append(decorators[decorator].proc)
 			run(kill_list, 'call')
 
 			time.sleep(0.5)
@@ -209,11 +209,12 @@ class CompizDecorator(object):
 		self.command = installed.decorators[name][1]
 		self.label = installed.decorators[name][2]
 		self.desktop = installed.decorators[name][3]
+		self.proc = installed.decorators[name][4]
 
 	def kill_others(self):
 		killall = ['killall']
 		for decorator in [x for x in self.decorators if x != self.name]:
-			killall.append(self.decorators[decorator].base)
+			killall.append(self.decorators[decorator].proc)
 		run(killall, 'call')
 
 class CompizDecorators(dict):

--- a/FusionIcon/util.py
+++ b/FusionIcon/util.py
@@ -161,7 +161,7 @@ class WindowManagers(dict):
 				time.sleep(1)
 
 		if self.active and self.old and 'noreplace' in self[self.active].flags:
-			run(['killall', self[self.old].base], 'call')
+			run(['pkill', self[self.old].base], 'call')
 			time.sleep(1)
 
 		if self.active == 'compiz':
@@ -172,7 +172,7 @@ class WindowManagers(dict):
 					if options[option].switch is not None:
 						compiz_command.append(options[option].switch)
 
-			kill_list = ['killall']
+			kill_list = ['pkill']
 			for decorator in decorators:
 				kill_list.append(decorators[decorator].proc)
 			run(kill_list, 'call')
@@ -212,10 +212,10 @@ class CompizDecorator(object):
 		self.proc = installed.decorators[name][4]
 
 	def kill_others(self):
-		killall = ['killall']
+		pkill = ['pkill']
 		for decorator in [x for x in self.decorators if x != self.name]:
-			killall.append(self.decorators[decorator].proc)
-		run(killall, 'call')
+			pkill.append(self.decorators[decorator].proc)
+		run(pkill, 'call')
 
 class CompizDecorators(dict):
 


### PR DESCRIPTION
Hi,

I've noticed that changing to xfwm4 works perfectly fine with --replace (and more consistently).

killall is not recognized as a command without the psmisc package, so I changed it to pkill (which is in most systems)

I also added a proc member to the decorators on data.py for the process name, mostly because the process name of the GTK window decorator is gtk-window-deco, not gtk-window-decorator.  Because of this, GTK would not be able to close when switching to a different decorator.